### PR TITLE
Fixed Scanner issue menu bug and improved try except block

### DIFF
--- a/getInstance.py
+++ b/getInstance.py
@@ -23,6 +23,12 @@ class BurpExtender(IBurpExtender, IContextMenuFactory):
 
 	def createMenuItems(self, invocation):
 		self.context = invocation
+		inv_context = invocation.getInvocationContext()
+
+
+		if inv_context == 7:
+			#not a valid menu
+		    return
 		menuList = ArrayList()
 		menuItem = JMenuItem("Get Depth Instance", actionPerformed=self.getDepthInstance)
 		menuList.add(menuItem)
@@ -42,8 +48,8 @@ class BurpExtender(IBurpExtender, IContextMenuFactory):
 				print 'host not resolved'
 			protocol = httpService.getProtocol()
 			port = httpService.getPort()
-		except UnicodeCodeError:
-			print 'get service error'
+		except:
+			print 'Could not get service details'
 		instance = ip + ' / ' + ' ' + host + ' : ' + 'tcp/udp' + '/' + str(port) + '/' + protocol
 		s = StringSelection(instance)
 		Toolkit.getDefaultToolkit().getSystemClipboard().setContents(s, s)


### PR DESCRIPTION
The get instance menu should no longer appear in scanner issue items when right-clicking. This prevents the extension trying to get info that is not available in that context. 

The try except block inside the main function was updated to be more generic instead of handling the 'unicode exception'. 